### PR TITLE
stu: Fehler beim Erfassen eines Pensum beheben.

### DIFF
--- a/src/main/java/ch/sbb/roteroktober/server/service/PensumService.java
+++ b/src/main/java/ch/sbb/roteroktober/server/service/PensumService.java
@@ -37,7 +37,7 @@ public class PensumService {
         PublicIdEntity publicId = publicIdService.createNewPublicId(PUBLIC_ID_PREFIX, PUBLIC_ID_LENGTH);
 
         // Alles in die Entität packen
-        entity.setPublicId(einsatzId);
+        entity.setPublicId(publicId.getPublicId());
         entity.setEinsatz(einsatz);
 
         // Speichern

--- a/src/test/java/ch/sbb/roteroktober/server/service/PensumIntegrationTest.java
+++ b/src/test/java/ch/sbb/roteroktober/server/service/PensumIntegrationTest.java
@@ -35,8 +35,23 @@ public class PensumIntegrationTest extends IntegrationTestBase {
         when().get("/mitarbeiter/" + uid + "/einsatz/" + einsatzId + "/pensum").then().body("size()", is(1));
         when().get("/pensum/" + pensumId).then().statusCode(200).body("publicId", is(pensumId));
 
+        // Und wir fügen nochmals einen Einsatz dazu
+        String pensum2Id = given().
+                body("{\"pensum\":60,\"anfang\":\"2015-02-01T00:00:00.000Z\", \"ende\":\"2015-06-01T00:00:00.000Z\"}").
+                contentType(ContentType.JSON).
+                post("/mitarbeiter/" + uid + "/einsatz/" + einsatzId + "/pensum").
+                then().
+                statusCode(200).
+                body("pensum", is(60)).
+                extract().path("publicId");
+
+        // Jetzt sollten zwei Pensen da sein
+        when().get("/mitarbeiter/" + uid + "/einsatz/" + einsatzId + "/pensum").then().body("size()", is(2));
+        when().get("/pensum/" + pensum2Id).then().statusCode(200).body("publicId", is(pensum2Id));
+
         // Pensum wieder löschen
         when().delete("/pensum/" + pensumId).then().statusCode(200);
+        when().delete("/pensum/" + pensum2Id).then().statusCode(200);
 
         // Jetzt sollte wieder alles weg sein
         when().get("/mitarbeiter/" + uid + "/einsatz/" + einsatzId + "/pensum").then().body("size()", is(0));


### PR DESCRIPTION
Beim Erfassen eines Pensum habe ich zwar einen neuen Schlüssel generiert, dann aber den öffentlichen Schlüssel des Einsatzes verwendet. Und der ist natürlich immer gleich. Schade über mich.