### PR TITLE
Feature/stu/auslastung berechnen

### DIFF
--- a/src/main/java/ch/sbb/roteroktober/server/model/PensumEntity.java
+++ b/src/main/java/ch/sbb/roteroktober/server/model/PensumEntity.java
@@ -33,6 +33,15 @@ public class PensumEntity extends PublicIdBaseEntity {
     @Column(name = "ende", nullable = true)
     private Date ende;
 
+    public PensumEntity() {
+    }
+
+    public PensumEntity(int pensum, Date anfang, Date ende) {
+        this.pensum = pensum;
+        this.anfang = anfang;
+        this.ende = ende;
+    }
+
     public EinsatzEntity getEinsatz() {
         return einsatz;
     }

--- a/src/main/java/ch/sbb/roteroktober/server/repo/PensumRepository.java
+++ b/src/main/java/ch/sbb/roteroktober/server/repo/PensumRepository.java
@@ -23,6 +23,9 @@ public interface PensumRepository extends CrudRepository<PensumEntity, Long> {
     @Query("SELECT p FROM PensumEntity p JOIN p.einsatz e JOIN e.mitarbeiter m WHERE m.uid = :uid AND e.publicId = :einsatzId AND p.deleted = false")
     List<PensumEntity> findByMitarbeiterAndEinsatz(@Param("uid") String uid, @Param("einsatzId") String einsatzId);
 
+    @Query("SELECT p FROM PensumEntity p JOIN p.einsatz e JOIN e.mitarbeiter m WHERE m.uid = :uid AND p.deleted = false")
+    List<PensumEntity> findByMitarbeiter(@Param("uid") String uid);
+
     @Transactional
     @Modifying(clearAutomatically = true)
     @Query("UPDATE PensumEntity p SET p.deleted = true, p.deletedAt = CURRENT_TIMESTAMP WHERE p.publicId = :publicId")

--- a/src/main/java/ch/sbb/roteroktober/server/rest/controller/AuslastungRestController.java
+++ b/src/main/java/ch/sbb/roteroktober/server/rest/controller/AuslastungRestController.java
@@ -1,0 +1,26 @@
+package ch.sbb.roteroktober.server.rest.controller;
+
+import ch.sbb.roteroktober.server.rest.model.AuslastungResource;
+import ch.sbb.roteroktober.server.service.AuslastungService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST-Schnittstelle für die Auslastung
+ */
+@RestController
+@RequestMapping(path = "/mitarbeiter/{uid}/auslastung")
+public class AuslastungRestController {
+    @Autowired
+    private AuslastungService auslastungService;
+
+    @RequestMapping(method = RequestMethod.GET)
+    public List<AuslastungResource> getAuslastung(@PathVariable("uid") String uid) {
+        return auslastungService.berechneAuslastung(uid);
+    }
+}

--- a/src/main/java/ch/sbb/roteroktober/server/rest/mapper/MitarbeiterMapper.java
+++ b/src/main/java/ch/sbb/roteroktober/server/rest/mapper/MitarbeiterMapper.java
@@ -4,6 +4,8 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 import ch.sbb.roteroktober.server.model.MitarbeiterEntity;
+import ch.sbb.roteroktober.server.rest.controller.AuslastungRestController;
+import ch.sbb.roteroktober.server.rest.controller.EinsatzRestController;
 import ch.sbb.roteroktober.server.rest.controller.MitarbeiterRestController;
 import ch.sbb.roteroktober.server.rest.model.MitarbeiterResource;
 import org.springframework.stereotype.Component;
@@ -21,6 +23,8 @@ public class MitarbeiterMapper {
         result.setOeName(entity.getOeName());
 
         result.add(linkTo(methodOn(MitarbeiterRestController.class).getByUid(entity.getUid())).withSelfRel());
+        result.add(linkTo(methodOn(EinsatzRestController.class).findAllByMitarbeiter(entity.getUid())).withRel("einsaetze"));
+        result.add(linkTo(methodOn(AuslastungRestController.class).getAuslastung(entity.getUid())).withRel("auslastung"));
 
         return result;
     }

--- a/src/main/java/ch/sbb/roteroktober/server/rest/model/AuslastungResource.java
+++ b/src/main/java/ch/sbb/roteroktober/server/rest/model/AuslastungResource.java
@@ -22,6 +22,15 @@ public class AuslastungResource {
     @JsonFormat(pattern = ResourceConstants.ISO_8601_DATE_PATTERN)
     private Date ende;
 
+    public AuslastungResource() {
+    }
+
+    public AuslastungResource(int pensum, Date anfang, Date ende) {
+        this.pensum = pensum;
+        this.anfang = anfang;
+        this.ende = ende;
+    }
+
     public int getPensum() {
         return pensum;
     }
@@ -44,5 +53,14 @@ public class AuslastungResource {
 
     public void setEnde(Date ende) {
         this.ende = ende;
+    }
+
+    @Override
+    public String toString() {
+        return "AuslastungResource{" +
+                "pensum=" + pensum +
+                ", anfang=" + anfang +
+                ", ende=" + ende +
+                '}';
     }
 }

--- a/src/main/java/ch/sbb/roteroktober/server/rest/model/AuslastungResource.java
+++ b/src/main/java/ch/sbb/roteroktober/server/rest/model/AuslastungResource.java
@@ -1,0 +1,48 @@
+package ch.sbb.roteroktober.server.rest.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.Date;
+
+/**
+ * Beschreibt die REST-Ressource für die Auslastung
+ */
+public class AuslastungResource {
+    @Min(0)
+    @Max(100)
+    private int pensum;
+
+    @NotNull
+    @JsonFormat(pattern = ResourceConstants.ISO_8601_DATE_PATTERN)
+    private Date anfang;
+
+    @JsonFormat(pattern = ResourceConstants.ISO_8601_DATE_PATTERN)
+    private Date ende;
+
+    public int getPensum() {
+        return pensum;
+    }
+
+    public void setPensum(int pensum) {
+        this.pensum = pensum;
+    }
+
+    public Date getAnfang() {
+        return anfang;
+    }
+
+    public void setAnfang(Date anfang) {
+        this.anfang = anfang;
+    }
+
+    public Date getEnde() {
+        return ende;
+    }
+
+    public void setEnde(Date ende) {
+        this.ende = ende;
+    }
+}

--- a/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
+++ b/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
@@ -19,6 +19,8 @@ public class AuslastungService {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(AuslastungService.class);
 
+    private final static Date HIGH_DATE = new GregorianCalendar(2999, 12, 31).getTime();
+
     @Autowired
     private PensumRepository pensumRepository;
 
@@ -113,6 +115,11 @@ public class AuslastungService {
                 continue;
             }
 
+            // Wenn möglich das Bis-Datum auf Null setzen
+            if (auslastung.getEnde().equals(HIGH_DATE)) {
+                auslastung.setEnde(null);
+            }
+
             // Wenn beide Elemente das gleiche Pensum haben, fügen wir es zusammen
             if (last.getPensum() == auslastung.getPensum()) {
                 AuslastungResource merged = new AuslastungResource(last.getPensum(), last.getAnfang(), auslastung.getEnde());
@@ -139,7 +146,7 @@ public class AuslastungService {
         int result = 0;
         for (PensumEntity pensum : pensumEntities) {
             if ((pensum.getAnfang().equals(datum) || pensum.getAnfang().before(datum))
-                    && (pensum.getEnde().equals(datum) || pensum.getEnde().after(datum))) {
+                    && (pensum.getEnde() == null || pensum.getEnde().equals(datum) || pensum.getEnde().after(datum))) {
                 result += pensum.getPensum();
             }
         }
@@ -160,7 +167,11 @@ public class AuslastungService {
 
             // Beim Ende-Datum setzten wir die Zeit immer auf Mitternacht, da wir davon ausgehen, dass immer der
             // ganze Tag gemeint ist
-            result.add(setEndOfDay(pensum.getEnde()));
+            if (pensum.getEnde() == null) {
+                result.add(HIGH_DATE);
+            } else {
+                result.add(setEndOfDay(pensum.getEnde()));
+            }
         }
 
         return result;

--- a/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
+++ b/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
@@ -4,7 +4,8 @@ import ch.sbb.roteroktober.server.model.PensumEntity;
 import ch.sbb.roteroktober.server.repo.PensumRepository;
 import ch.sbb.roteroktober.server.rest.model.AuslastungResource;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +16,8 @@ import java.util.*;
  */
 @Component
 public class AuslastungService {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(AuslastungService.class);
 
     @Autowired
     private PensumRepository pensumRepository;
@@ -34,20 +37,21 @@ public class AuslastungService {
         List<AuslastungResource> auslastungRaw = berechneAulastungRaw(pensumEntities, pensumAenderungen);
 
         // Mal alle Auslastungen ausgeben
-        printAuslastungen(auslastungRaw, "Auslastung Raw");
+        logAuslastung(auslastungRaw, "Auslastung Raw");
 
         // Auslastungen bereinigen und glätten.
         List<AuslastungResource> result = glaetteAuslastung(auslastungRaw);
-        printAuslastungen(result, "Resultat");
+        logAuslastung(result, "Resultat");
         return result;
     }
 
-    private void printAuslastungen(List<AuslastungResource> auslastungRaw, String title) {
-        System.out.println();
-        System.out.println(title);
-        System.out.println(StringUtils.repeat("=", title.length()));
-        for (AuslastungResource auslastung : auslastungRaw) {
-            System.out.println(auslastung);
+    private void logAuslastung(List<AuslastungResource> auslastungRaw, String title) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(title);
+            LOGGER.debug(StringUtils.repeat("=", title.length()));
+            for (AuslastungResource auslastung : auslastungRaw) {
+                LOGGER.debug(auslastung.toString());
+            }
         }
     }
 

--- a/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
+++ b/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
@@ -1,0 +1,29 @@
+package ch.sbb.roteroktober.server.service;
+
+import ch.sbb.roteroktober.server.model.PensumEntity;
+import ch.sbb.roteroktober.server.repo.PensumRepository;
+import ch.sbb.roteroktober.server.rest.model.AuslastungResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Berechnet die Auslastung eines Mitarbeiters
+ */
+@Component
+public class AuslastungService {
+
+    @Autowired
+    private PensumRepository pensumRepository;
+
+    public List<AuslastungResource> berechneAuslastung(String uid) {
+        // Alle Pensen für diesen Benutzer laden
+        List<PensumEntity> pensen = pensumRepository.findByMitarbeiter(uid);
+        return berechneAuslastung(pensen);
+    }
+
+    public List<AuslastungResource> berechneAuslastung(List<PensumEntity> pensumEntities) {
+        return null;
+    }
+}

--- a/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
+++ b/src/main/java/ch/sbb/roteroktober/server/service/AuslastungService.java
@@ -3,10 +3,12 @@ package ch.sbb.roteroktober.server.service;
 import ch.sbb.roteroktober.server.model.PensumEntity;
 import ch.sbb.roteroktober.server.repo.PensumRepository;
 import ch.sbb.roteroktober.server.rest.model.AuslastungResource;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.util.*;
 
 /**
  * Berechnet die Auslastung eines Mitarbeiters
@@ -24,6 +26,154 @@ public class AuslastungService {
     }
 
     public List<AuslastungResource> berechneAuslastung(List<PensumEntity> pensumEntities) {
-        return null;
+        // Alle Daten ermitteln, an welchen ein Pensum entweder beginnt oder aufhört. Denn immer dort
+        // müssen wir bei der Berechnung der Auslastung hinschauen, weil sich etwas ändert.
+        SortedSet<Date> pensumAenderungen = ermittlePensumAenderung(pensumEntities);
+
+        // Auslastungen einmal sehr detailliert berechnen
+        List<AuslastungResource> auslastungRaw = berechneAulastungRaw(pensumEntities, pensumAenderungen);
+
+        // Mal alle Auslastungen ausgeben
+        printAuslastungen(auslastungRaw, "Auslastung Raw");
+
+        // Auslastungen bereinigen und glätten.
+        List<AuslastungResource> result = glaetteAuslastung(auslastungRaw);
+        printAuslastungen(result, "Resultat");
+        return result;
+    }
+
+    private void printAuslastungen(List<AuslastungResource> auslastungRaw, String title) {
+        System.out.println();
+        System.out.println(title);
+        System.out.println(StringUtils.repeat("=", title.length()));
+        for (AuslastungResource auslastung : auslastungRaw) {
+            System.out.println(auslastung);
+        }
+    }
+
+    /**
+     * Berechnet die Auslastung aufgrund jeder Änderung des Pensums. Es wird noch nicht berücksichtigt, ob zwei
+     * auseinander folgende Pensen den gleichen Wert haben.
+     * @param pensen Liste mit den Pensen
+     * @param pensumAenderungen Liste mit den Daten, an welchen es Änderungen gibt
+     * @return Liste mit den Auslastungen
+     */
+    private List<AuslastungResource> berechneAulastungRaw(List<PensumEntity> pensen, SortedSet<Date> pensumAenderungen) {
+        List<AuslastungResource> auslastungRaw = new ArrayList<>();
+        Date lastAenderung = null;
+        for (Date pensumAenderung : pensumAenderungen) {
+            // Uns interessiert immer das Paar der letzten und aktuellen Änderung
+            if(lastAenderung == null){
+                lastAenderung = pensumAenderung;
+                continue;
+            }
+
+            // Auslastung zu diesem Zeitpunkt ermitteln
+            int auslastung = ermittleAuslastung(pensen, lastAenderung);
+
+            // Auslastung erstellen
+            AuslastungResource auslastungResource = new AuslastungResource(auslastung, lastAenderung, pensumAenderung);
+            auslastungRaw.add(auslastungResource);
+
+            // Das letzte Pensum überschreiben
+            lastAenderung = pensumAenderung;
+        }
+        return auslastungRaw;
+    }
+
+    /**
+     * Bereinigt eine Liste von Auslastungen. Dabei wir folgendes durchgeführt:
+     * * Zu kurze Element (nur wenige Sekunden) werden entfernt
+     * * Elemente mit dem gleichen Wert werden zusammengeführt
+     * @param auslastungen Liste mit den zu glättenden Auslastungen
+     * @return Geglättete Auslastungen
+     */
+    private List<AuslastungResource> glaetteAuslastung(List<AuslastungResource> auslastungen) {
+        Stack<AuslastungResource> stack = new Stack<>();
+
+        for (AuslastungResource auslastung : auslastungen) {
+            // Wenn noch nichts auf dem Stack ist, dann legen wir die Auslastung einfach drauf
+            if (stack.isEmpty()) {
+                stack.push(auslastung);
+                continue;
+            }
+
+            // Letztes Element vom Stack nehmen
+            AuslastungResource last = stack.peek();
+
+            // Dauer des Elementes überprüfen
+            long duration = auslastung.getEnde().getTime() - auslastung.getAnfang().getTime();
+
+            // Wenn die Dauer unter einer Minute ist, dann ignorieren wir dieses Element
+            if (duration < 1000 * 60) {
+                continue;
+            }
+
+            // Wenn beide Elemente das gleiche Pensum haben, fügen wir es zusammen
+            if (last.getPensum() == auslastung.getPensum()) {
+                AuslastungResource merged = new AuslastungResource(last.getPensum(), last.getAnfang(), auslastung.getEnde());
+                stack.pop();
+                stack.push(merged);
+                continue;
+            }
+
+            // Element ohne Anpassungen drauflegen
+            stack.push(auslastung);
+        }
+
+        return stack;
+    }
+
+    /**
+     * Ermittelt die Auslastung an einem bestimmten Tag. Dazu wird festgestellt, welche Pensen an diesem Tag gültig
+     * sind und anschliessend deren Prozentwerte zusammengezählt
+     * @param pensumEntities Liste mit den Pensen, welche durchsucht werden sollen
+     * @param datum Datum, an welchem die Auslastung ermittelt werden soll
+     * @return Auslastung zum gegebenen Zeitpunkt. 0, wenn kein Pensum vorhanden ist
+     */
+    private int ermittleAuslastung(List<PensumEntity> pensumEntities, Date datum) {
+        int result = 0;
+        for (PensumEntity pensum : pensumEntities) {
+            if ((pensum.getAnfang().equals(datum) || pensum.getAnfang().before(datum))
+                    && (pensum.getEnde().equals(datum) || pensum.getEnde().after(datum))) {
+                result += pensum.getPensum();
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Ermittelt alle Daten, an welchen ein Pensum beginnt oder endet. Dies sind alle Orte, an welchen sich die
+     * Auslastung potentiell ändern kann.
+     * @param pensumEntities Liste mit den Entitäten
+     * @return Sortiertes Set mit den ermittelten Daten, wen welchen sich das Pensum ändert
+     */
+    private SortedSet<Date> ermittlePensumAenderung(List<PensumEntity> pensumEntities) {
+        SortedSet<Date> result = new TreeSet<>();
+
+        for (PensumEntity pensum : pensumEntities) {
+            result.add(pensum.getAnfang());
+
+            // Beim Ende-Datum setzten wir die Zeit immer auf Mitternacht, da wir davon ausgehen, dass immer der
+            // ganze Tag gemeint ist
+            result.add(setEndOfDay(pensum.getEnde()));
+        }
+
+        return result;
+    }
+
+    /**
+     * Der die Zeit eines Datums auf Ende des Tages, sprich 23:59:59:999
+     * @param date Datum, dessen Zeit geändert werden soll
+     * @return Datum mit Zeit zu Ende des Tages
+     */
+    private Date setEndOfDay(Date date) {
+        Calendar cal = new GregorianCalendar();
+        cal.setTime(date);
+        cal.set(Calendar.HOUR, 23);
+        cal.set(Calendar.MINUTE, 59);
+        cal.set(Calendar.SECOND, 59);
+        cal.set(Calendar.MILLISECOND, 999);
+        return cal.getTime();
     }
 }

--- a/src/test/java/ch/sbb/roteroktober/server/service/AuslastungServiceTest.java
+++ b/src/test/java/ch/sbb/roteroktober/server/service/AuslastungServiceTest.java
@@ -30,7 +30,7 @@ public class AuslastungServiceTest {
         List<PensumEntity> pensen = new ArrayList<>();
         pensen.add(new PensumEntity(60, cd(2015, 1, 1), cd(2015, 7, 31)));
         pensen.add(new PensumEntity(80, cd(2015, 8, 1), cd(2016, 7, 31)));
-        pensen.add(new PensumEntity(80, cd(2016, 8, 1), cd(2016, 10, 31)));
+        pensen.add(new PensumEntity(80, cd(2016, 8, 1), null));
         pensen.add(new PensumEntity(30, cd(2015, 6, 1), cd(2015, 12, 31)));
         pensen.add(new PensumEntity(20, cd(2016, 3, 1), cd(2016, 3, 31)));
         pensen.add(new PensumEntity(20, cd(2016, 4, 1), cd(2016, 4, 30)));
@@ -46,7 +46,7 @@ public class AuslastungServiceTest {
         checkAuslastung(result.get(2), 110, cd(2015, 8, 1), cd(2015, 12, 31));
         checkAuslastung(result.get(3), 80, cd(2015, 12, 31), cd(2016, 3, 1));
         checkAuslastung(result.get(4), 100, cd(2016, 3, 1), cd(2016, 4, 30));
-        checkAuslastung(result.get(5), 80, cd(2016, 4, 30), cd(2016, 10, 31));
+        checkAuslastung(result.get(5), 80, cd(2016, 4, 30), null);
     }
 
     private void checkAuslastung(AuslastungResource result, int pensum, Date start, Date ende) {
@@ -57,9 +57,13 @@ public class AuslastungServiceTest {
         Assert.assertEquals(start.getMonth(), result.getAnfang().getMonth());
         Assert.assertEquals(start.getDate(), result.getAnfang().getDate());
 
-        Assert.assertEquals(ende.getYear(), result.getEnde().getYear());
-        Assert.assertEquals(ende.getMonth(), result.getEnde().getMonth());
-        Assert.assertEquals(ende.getDate(), result.getEnde().getDate());
+        if(ende != null) {
+            Assert.assertEquals(ende.getYear(), result.getEnde().getYear());
+            Assert.assertEquals(ende.getMonth(), result.getEnde().getMonth());
+            Assert.assertEquals(ende.getDate(), result.getEnde().getDate());
+        } else {
+            Assert.assertNull(result.getEnde());
+        }
     }
 
     private Date cd(int year, int month, int day) {

--- a/src/test/java/ch/sbb/roteroktober/server/service/AuslastungServiceTest.java
+++ b/src/test/java/ch/sbb/roteroktober/server/service/AuslastungServiceTest.java
@@ -1,0 +1,70 @@
+package ch.sbb.roteroktober.server.service;
+
+import ch.sbb.roteroktober.server.model.PensumEntity;
+import ch.sbb.roteroktober.server.rest.model.AuslastungResource;
+import org.apache.commons.lang3.time.DateUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unittest für die Klasse {@link AuslastungService}
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AuslastungServiceTest {
+
+    @InjectMocks
+    private AuslastungService auslastungService;
+
+    @Test
+    public void berechneAuslastung() throws Exception {
+        // Pensen erstellen
+        List<PensumEntity> pensen = new ArrayList<>();
+        pensen.add(new PensumEntity(60, cd(2015, 1, 1), cd(2015, 7, 31)));
+        pensen.add(new PensumEntity(80, cd(2015, 8, 1), cd(2016, 7, 31)));
+        pensen.add(new PensumEntity(80, cd(2016, 8, 1), cd(2016, 10, 31)));
+        pensen.add(new PensumEntity(30, cd(2015, 6, 1), cd(2015, 12, 31)));
+        pensen.add(new PensumEntity(20, cd(2016, 3, 1), cd(2016, 3, 31)));
+        pensen.add(new PensumEntity(20, cd(2016, 4, 1), cd(2016, 4, 30)));
+
+        // Test ausführen
+        List<AuslastungResource> result = auslastungService.berechneAuslastung(pensen);
+
+        // Resultat überprüfen
+        Assert.assertNotNull(result);
+        Assert.assertEquals(6, result.size());
+        checkAuslastung(result.get(0), 60, cd(2015, 1, 1), cd(2015, 5, 31));
+        checkAuslastung(result.get(1), 90, cd(2015, 6, 1), cd(2015, 7, 31));
+        checkAuslastung(result.get(2), 110, cd(2015, 8, 1), cd(2015, 12, 31));
+        checkAuslastung(result.get(3), 80, cd(2016, 1, 1), cd(2016, 2, 29));
+        checkAuslastung(result.get(4), 100, cd(2016, 3, 1), cd(2016, 4, 30));
+        checkAuslastung(result.get(5), 80, cd(2016, 5, 1), cd(2016, 10, 31));
+    }
+
+    private void checkAuslastung(AuslastungResource result, int pensum, Date start, Date ende) {
+        Assert.assertNotNull(result);
+        Assert.assertEquals(pensum, result.getPensum());
+
+        Assert.assertEquals(start.getYear(), result.getAnfang().getYear());
+        Assert.assertEquals(start.getMonth(), result.getAnfang().getMonth());
+        Assert.assertEquals(start.getDate(), result.getAnfang().getDate());
+
+        Assert.assertEquals(ende.getYear(), result.getEnde().getYear());
+        Assert.assertEquals(ende.getMonth(), result.getEnde().getMonth());
+        Assert.assertEquals(ende.getDate(), result.getEnde().getDate());
+    }
+
+    private Date cd(int year, int month, int day) {
+        LocalDate date = LocalDate.of(year, month, day);
+        return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    }
+
+}

--- a/src/test/java/ch/sbb/roteroktober/server/service/AuslastungServiceTest.java
+++ b/src/test/java/ch/sbb/roteroktober/server/service/AuslastungServiceTest.java
@@ -41,12 +41,12 @@ public class AuslastungServiceTest {
         // Resultat überprüfen
         Assert.assertNotNull(result);
         Assert.assertEquals(6, result.size());
-        checkAuslastung(result.get(0), 60, cd(2015, 1, 1), cd(2015, 5, 31));
+        checkAuslastung(result.get(0), 60, cd(2015, 1, 1), cd(2015, 6, 1));
         checkAuslastung(result.get(1), 90, cd(2015, 6, 1), cd(2015, 7, 31));
         checkAuslastung(result.get(2), 110, cd(2015, 8, 1), cd(2015, 12, 31));
-        checkAuslastung(result.get(3), 80, cd(2016, 1, 1), cd(2016, 2, 29));
+        checkAuslastung(result.get(3), 80, cd(2015, 12, 31), cd(2016, 3, 1));
         checkAuslastung(result.get(4), 100, cd(2016, 3, 1), cd(2016, 4, 30));
-        checkAuslastung(result.get(5), 80, cd(2016, 5, 1), cd(2016, 10, 31));
+        checkAuslastung(result.get(5), 80, cd(2016, 4, 30), cd(2016, 10, 31));
     }
 
     private void checkAuslastung(AuslastungResource result, int pensum, Date start, Date ende) {


### PR DESCRIPTION
Jetzt kann die Auslastung auf einem Mitarbeiter ermittelt werden. Die URL ist wie folgt aufgebaut:
`/mitarbeiter/{uid}/auslastung`

Das Resultat kommt im gleichen Format zurück wie die Pensen. Hier ein Beispiel:
```json
[
  {
    "pensum": 100,
    "anfang": "2013-12-31T23:00:00.000Z",
    "ende": "2016-08-31T22:00:00.000Z"
  },
  {
    "pensum": 130,
    "anfang": "2016-08-31T22:00:00.000Z",
    "ende": null
  }
]
```
@kreuzerk: Schafft du es, dies morgen ins Frontend einzubauen damit ich es am Freitag demonstrieren kann?